### PR TITLE
docs: add the config in readme.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,15 @@ exports.rest = {
 };
 ```
 
-Configure the rest plugin in `config/config.default.js`:
+Custom Config: Developers can custom some options to satisfy their own situations
+
+- `urlperfix` :  Prefix of rest api url. Defaluts to /api/
+- `authRequest`:  a function for getting some value of authentication
+- ` authIgnores`:  allow some request to ignore authentication
+- `errorResponse`:  Error handling function
+
+
+Example: Configure the rest plugin in `config/config.default.js`:
 
 ```js
 exports.rest = {
@@ -64,13 +72,9 @@ exports.rest = {
   //     index: true,
   //   }
   // }
-  errorResponse: null
-  // errorResponse: function* (ctx, err){
-  //     // give some error handling by yourself
-  // }
-  //
 };
 ```
+
 
 Controllers in files matching `${baseDir}/app/apis/**.js` will be loaded automatically according to routing rules.
 

--- a/README.md
+++ b/README.md
@@ -64,6 +64,11 @@ exports.rest = {
   //     index: true,
   //   }
   // }
+  errorResponse: null
+  // errorResponse: function* (ctx, err){
+  //     // give some error handling by yourself
+  // }
+  //
 };
 ```
 

--- a/README.md
+++ b/README.md
@@ -43,12 +43,14 @@ exports.rest = {
 };
 ```
 
-Custom Config: Developers can custom some options to satisfy their own situations
+## Configuration
 
-- `urlperfix` :  Prefix of rest api url. Defaluts to /api/
-- `authRequest`:  a function for getting some value of authentication
-- ` authIgnores`:  allow some request to ignore authentication
-- `errorResponse`:  Error handling function
+egg-rest supports some configurations below:
+
+- urlperfix: `Prefix of rest api url. Defaluts to /api/`
+- authRequest: `a function for getting some value of authentication`
+- authIgnores: `allow some request to ignore authentication`
+- errorResponse: `Error handling function`
 
 
 Example: Configure the rest plugin in `config/config.default.js`:

--- a/README.md
+++ b/README.md
@@ -45,8 +45,7 @@ exports.rest = {
 
 ## Configuration
 
-
-- `urlperfix`: Prefix of rest api url. Defalut to /api/
+- `urlperfix`: Prefix of rest api url. Default to `/api/`
 - `authRequest`: a function for getting some value of authentication
 - `authIgnores`: allow some request to ignore authentication
 - `errorResponse`: Error handling function
@@ -56,7 +55,7 @@ Example: Configure the rest plugin in `config/config.default.js`:
 
 ```js
 exports.rest = {
-  urlprefix: '/doc/api/', // Prefix of rest api url. Defalut to /api/
+  urlprefix: '/doc/api/', // Prefix of rest api url. Default to /api/
   authRequest: null,
   // authRequest: function* (ctx) {
   //   // A truthy value must be returned when authentication succeeds.

--- a/README.md
+++ b/README.md
@@ -45,19 +45,18 @@ exports.rest = {
 
 ## Configuration
 
-egg-rest supports some configurations below:
 
-- urlperfix: `Prefix of rest api url. Defaluts to /api/`
-- authRequest: `a function for getting some value of authentication`
-- authIgnores: `allow some request to ignore authentication`
-- errorResponse: `Error handling function`
+- `urlperfix`: Prefix of rest api url. Defalut to /api/
+- `authRequest`: a function for getting some value of authentication
+- `authIgnores`: allow some request to ignore authentication
+- `errorResponse`: Error handling function
 
 
 Example: Configure the rest plugin in `config/config.default.js`:
 
 ```js
 exports.rest = {
-  urlprefix: '/doc/api/', // Prefix of rest api url. Defaluts to /api/
+  urlprefix: '/doc/api/', // Prefix of rest api url. Defalut to /api/
   authRequest: null,
   // authRequest: function* (ctx) {
   //   // A truthy value must be returned when authentication succeeds.


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests and possibly benchmarks.
Contributors guide: https://github.com/eggjs/egg/blob/master/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试，必要时请附上性能测试。
Contributors guide: https://github.com/eggjs/egg/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `npm test` passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s). -->


##### Description of change
<!-- Provide a description of the change below this comment. -->
`readme.md`文档中没有提及到`egg-rest`插件可以配置一个`errorResponse`来自定义自己的错误捕获事件，导致[issue](https://github.com/eggjs/egg/issues/1623#issuecomment-342783909)中有关于`egg-rest`使用过程中`catch`不到错误的问题。
所以希望在文档中加上这块的配置说明